### PR TITLE
Update gtfs_tables_makespatial

### DIFF
--- a/src/gtfs_tables_makespatial.sql
+++ b/src/gtfs_tables_makespatial.sql
@@ -11,7 +11,7 @@ SELECT AddGeometryColumn('gtfs_stops', 'the_geom', 4326, 'POINT', 2);
 UPDATE gtfs_stops SET the_geom = ST_SetSRID(ST_MakePoint(stop_lon, stop_lat), 4326);
 
 -- Create spatial index
-CREATE INDEX "gtfs_stops_the_geom_gist" ON "gtfs_stops" using gist ("the_geom" gist_geometry_ops);
+CREATE INDEX "gtfs_stops_the_geom_gist" ON "gtfs_stops" using gist ("the_geom");
 
 -- Create new table to store the shape geometries
 CREATE TABLE gtfs_shape_geoms (
@@ -32,6 +32,6 @@ SELECT shape.shape_id, ST_SetSRID(ST_MakeLine(shape.the_geom), 4326) As new_geom
 GROUP BY shape.shape_id;
 
 -- Create spatial index
-CREATE INDEX "gtfs_shape_geoms_the_geom_gist" ON "gtfs_shape_geoms" using gist ("the_geom" gist_geometry_ops);
+CREATE INDEX "gtfs_shape_geoms_the_geom_gist" ON "gtfs_shape_geoms" using gist ("the_geom");
 
 COMMIT;


### PR DESCRIPTION
Remove "gist_geometry_ops" as no longer supported by PostGIS and prevented importing GTFS feed correctly. Refer https://gis.stackexchange.com/a/91389.